### PR TITLE
EODHP-187 - Web Presence postgres database persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,17 @@
 # Changelog
 
+## v0.1.7 (05-04-2024)
+
+- Moved persistent volume for postgres
+
 ## v0.1.6 (02-04-2024)
 
 - Update to use v0.1.6 docker image 
-- 
+
 ## v0.1.5 (02-04-2024)
 
 - Update to use v0.1.5 docker image 
-  
+
 ## v0.1.4 (20-03-2024)
 
 - Add notebook environment variable

--- a/eodhp-web-presence/Chart.yaml
+++ b/eodhp-web-presence/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: eodhp-web-presence
 description: The EODHP Web Presence
 type: application
-version: 0.1.6
-appVersion: "0.1.6"
+version: 0.1.7
+appVersion: "0.1.7"

--- a/eodhp-web-presence/templates/database-statefulset.yaml
+++ b/eodhp-web-presence/templates/database-statefulset.yaml
@@ -24,9 +24,12 @@ spec:
               value: {{ .Values.database.sql_user | default "admin" }}
             - name: POSTGRES_PASSWORD
               value: {{ .Values.database.sql_password | default "password" }}
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
           volumeMounts:
             - name: postgres-persistent-storage
-              mountPath: /var/lib/postgres
+              mountPath: /var/lib/postgresql/data
+              subpath: pgdata
 
   volumeClaimTemplates:
     - metadata:

--- a/eodhp-web-presence/templates/web-presence-deploy.yaml
+++ b/eodhp-web-presence/templates/web-presence-deploy.yaml
@@ -42,9 +42,3 @@ spec:
               value: {{ .Values.catalogue_data.url | default "https://my-stac-browser-data.com/catalog.json" }}
             - name: NOTEBOOKS_URL
               value: {{ .Values.notebooks.url | default "https://notebooks.co.uk/apphub" }}
-            - name: WEB_PRESENCE_STATIC_S3_BUCKET
-              value: {{ .Values.aws.static_s3_bucket | default "my_s3_bucket" }}
-            - name: AWS_REGION_NAME
-              value: {{ .Values.aws.region | default "eu-west-2" }}
-            - name: ENVIRONMENT_NAME
-              value: {{ .Values.environment.name | default "env" }}

--- a/eodhp-web-presence/values.yaml
+++ b/eodhp-web-presence/values.yaml
@@ -35,3 +35,6 @@ aws:
   static_s3_bucket: static-bucket
 
 storage_class: standard
+
+environment:
+  name: test


### PR DESCRIPTION
Moved persistent storage for postgres under the postgres default install. Set PGDATA to the same location for clarity.
Some cleanup of web presence env variables.
Draft review pending other changes to web presence v0.1.7.