### PR TITLE
Use 'Always' pull policy

### DIFF
--- a/eodhp-web-presence/Chart.yaml
+++ b/eodhp-web-presence/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: eodhp-web-presence
 description: The EODHP Web Presence
 type: application
-version: 0.1.12
+version: v0.1.12-test-devex-image-build-caches
 appVersion: "0.1.12"

--- a/eodhp-web-presence/Chart.yaml
+++ b/eodhp-web-presence/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: eodhp-web-presence
 description: The EODHP Web Presence
 type: application
-version: v0.1.12-test-devex-image-build-caches-2
-appVersion: "0.1.12"
+version: v0.1.12-test-devex-image-build-caches-4
+appVersion: "0.1.12-test-devex-image-build-caches-4"

--- a/eodhp-web-presence/Chart.yaml
+++ b/eodhp-web-presence/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: eodhp-web-presence
 description: The EODHP Web Presence
 type: application
-version: v0.1.12-test-devex-image-build-caches-4
-appVersion: "0.1.12-test-devex-image-build-caches-4"
+version: v0.1.12-test-devex-image-build-caches-5
+appVersion: "v0.1.12-test-devex-image-build-caches-5"

--- a/eodhp-web-presence/Chart.yaml
+++ b/eodhp-web-presence/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: eodhp-web-presence
 description: The EODHP Web Presence
 type: application
-version: 0.1.12-test-devex-image-build-caches-6
-appVersion: "0.1.12-test-devex-image-build-caches-6"
+version: 0.1.12
+appVersion: "0.1.12"

--- a/eodhp-web-presence/Chart.yaml
+++ b/eodhp-web-presence/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: eodhp-web-presence
 description: The EODHP Web Presence
 type: application
-version: v0.1.12-test-devex-image-build-caches-5
-appVersion: "v0.1.12-test-devex-image-build-caches-5"
+version: 0.1.12-test-devex-image-build-caches-6
+appVersion: "0.1.12-test-devex-image-build-caches-6"

--- a/eodhp-web-presence/Chart.yaml
+++ b/eodhp-web-presence/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: eodhp-web-presence
 description: The EODHP Web Presence
 type: application
-version: v0.1.12-test-devex-image-build-caches
+version: v0.1.12-test-devex-image-build-caches-2
 appVersion: "0.1.12"

--- a/eodhp-web-presence/templates/migrate-job.yaml
+++ b/eodhp-web-presence/templates/migrate-job.yaml
@@ -8,6 +8,7 @@ spec:
       containers:
       - name: db-migrate
         image: {{ .Values.image | default "public.ecr.aws/n1b3o1k2/eodhp-web-presence:0.1.12" }}
+        imagePullPolicy: Always
         command: ["sh", "-c", "python manage.py migrate"]
         env:
           - name: SQL_HOST

--- a/eodhp-web-presence/templates/web-presence-deploy.yaml
+++ b/eodhp-web-presence/templates/web-presence-deploy.yaml
@@ -16,6 +16,7 @@ spec:
       containers:
         - name: eodhp-web-presence
           image: {{ .Values.image | default "public.ecr.aws/n1b3o1k2/eodhp-web-presence:0.1.12" }}
+          imagePullPolicy: Always
           ports:
             - containerPort: 8000
           env:


### PR DESCRIPTION
Use the 'Always' imagePullPolicy so that we can use the changes to the eodhp-web-presence repo to automatically create branch-latest images. Without this, we can create a new image but the cluster doesn't always use it.

When the image hasn't changed it checks the image hash rather than blindly pulling, so there should be little performance impact.
